### PR TITLE
Hidden the Api key for SendGrid email

### DIFF
--- a/main/BitBracket/src/BitBracket/appsettings.json
+++ b/main/BitBracket/src/BitBracket/appsettings.json
@@ -10,6 +10,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "SendGridKey": "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"
+  "AllowedHosts": "*"
 }


### PR DESCRIPTION
Set a user-secret key for the Api.